### PR TITLE
Remove deprecated effect annotations

### DIFF
--- a/src/Lsp/Server.flix
+++ b/src/Lsp/Server.flix
@@ -106,18 +106,18 @@ mod SG.Lsp.Server {
 
     def mkTextDocumentService(s: Server[r]): TextDocumentService \ IO = {
         new TextDocumentService {
-            def didOpen(_this: TextDocumentService, params: DidOpenTextDocumentParams): Unit \ IO + Net + r = {
+            def didOpen(_this: TextDocumentService, params: DidOpenTextDocumentParams): Unit \ IO + r = {
                 System.err.println("didOpen");
                 s |> addUriIfNotPresent(params.getTextDocument().getUri())
             }
             def didClose(_this: TextDocumentService, _params: DidCloseTextDocumentParams): Unit \ IO = {
                 System.err.println("didClose")
             }
-            def didChange(_this: TextDocumentService, params: DidChangeTextDocumentParams): Unit \ IO + Net + r = {
+            def didChange(_this: TextDocumentService, params: DidChangeTextDocumentParams): Unit \ IO + r = {
                 System.err.println("didChange");
                 s |> updateUri(params.getTextDocument().getUri())
             }
-            def didSave(_this: TextDocumentService, params: DidSaveTextDocumentParams): Unit \ IO + Net + r = {
+            def didSave(_this: TextDocumentService, params: DidSaveTextDocumentParams): Unit \ IO + r = {
                 System.err.println("didSave");
                 s |> updateUri(params.getTextDocument().getUri())
             }
@@ -144,7 +144,7 @@ mod SG.Lsp.Server {
                     toArrayList;
                 CompletableFuture.completedFuture(list)
             }
-            def definition(_this: TextDocumentService, params: DefinitionParams): CompletableFuture \ IO + Net + r = {
+            def definition(_this: TextDocumentService, params: DefinitionParams): CompletableFuture \ IO + r = {
                 System.err.println("definition");
                 let uri = params.getTextDocument().getUri();
                 s |> addUriIfNotPresent(params.getTextDocument().getUri());
@@ -172,11 +172,11 @@ mod SG.Lsp.Server {
         }
     }
 
-    def addUriIfNotPresent(uri: String, s: Server[r]): Unit \ r + IO + Net = {
+    def addUriIfNotPresent(uri: String, s: Server[r]): Unit \ r + IO = {
         addFileIfNotPresent(pathFromUri(uri), s)
     }
 
-    def updateUri(uri: String, s: Server[r]): Unit \ r + IO + Net = {
+    def updateUri(uri: String, s: Server[r]): Unit \ r + IO = {
         updateFile(pathFromUri(uri), s)
     }
 
@@ -198,7 +198,7 @@ mod SG.Lsp.Server {
         }
     }
 
-    def pathFromUri(uri: String): String \ IO + Net = {
+    def pathFromUri(uri: String): String \ IO = {
         Paths.get(new URI(uri)).toString()
     }
 

--- a/src/Main.flix
+++ b/src/Main.flix
@@ -1,6 +1,6 @@
 use SG.Manager
 
-def main(): Unit \ IO + Sys = {
+def main(): Unit \ IO = {
     let res = run mainAux() with Environment.runWithIO with FileRead.runWithIO;
     match res {
         case Result.Ok(()) => ()


### PR DESCRIPTION
The community build on Flix breaks, since effect annotations (except for `IO`) are deprecated :)